### PR TITLE
Add drafter configuration

### DIFF
--- a/.github/release_drafter_config.yml
+++ b/.github/release_drafter_config.yml
@@ -1,0 +1,48 @@
+---
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
+template: |
+  ## Changes
+
+  $CHANGES
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+change-template: '- #$NUMBER $TITLE (@$AUTHOR)'
+# You can add # and @ to disable mentions, and add ` to disable code blocks.
+change-title-escapes: '\<*_&'
+version-resolver:
+  major:
+    labels:
+      - 'type: breaking'
+  minor:
+    labels:
+      - 'type: enhancement'
+  patch:
+    labels:
+      - 'type: bug'
+      - 'type: documentation'
+      - 'type: maintenance'
+      - 'type: dependencies'
+  default: patch
+autolabeler:
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+      - '/bugfix\/.+/'
+      - '/bug\/.+/'
+    title:
+      - '/fix/i'
+  - label: 'enhancement'
+    branch:
+      - '/feature\/.+/'
+      - '/enhancement\/.+/'
+exclude-lables:
+  - 'skip-changelog'


### PR DESCRIPTION
`release-drafter` action requires the configuration file on the default branch (`master` in this repo) to function properly. This PR cherry picks the configuration file from #12 from that PR to properly test.

- trail version, this configuration may need some updates.